### PR TITLE
By clicking 'Add all' the skeletal subdivisions are loaded again properly

### DIFF
--- a/productMods/js/formGeneration/FormElements.js
+++ b/productMods/js/formGeneration/FormElements.js
@@ -154,12 +154,14 @@ class Adder extends FormElement{
 		this.addedForms = []
 		$.each(data, (function(key, value) {
 			// The key is the uri
-			this.cnt++
-			var object = new Object()
-			object[this.dataKey] = key
-			object[this.dataKey + "Label"] = this.options[key].label
-			this.dataArray.push(object)
-			this.subForms.push(new SubFormAll(this, this.descriptor, object))
+			if(key != "queries"){
+				this.cnt++
+				var object = new Object()
+				object[this.dataKey] = key
+				object[this.dataKey + "Label"] = this.options[key].label
+				this.dataArray.push(object)
+				this.subForms.push(new SubFormAll(this, this.descriptor, object))
+			}
 		}).bind(this))
 	}
 


### PR DESCRIPTION
Otherwise by the clicking the 'Add all' button, approximately once from 10 tries (so with 10% probability), one of the form data loader requests eventually fails, and this results that the for both Neurocranium and Viscerocranium the same set of bone organs are offered. If you experience this, then just please reload the page. I will fix this issue later.