### PR TITLE
Drawing conclusion

### DIFF
--- a/productMods/WEB-INF/web.xml
+++ b/productMods/WEB-INF/web.xml
@@ -1129,6 +1129,15 @@
     <url-pattern>/dataTransformationAJAX</url-pattern>
   </servlet-mapping>  
   
+  <servlet>
+    <servlet-name>DrawingConclusionServlet</servlet-name>
+    <servlet-class>edu.cornell.mannlib.vitro.webapp.search.controller.DrawingConclusionAJAXController</servlet-class>
+  </servlet>
+  <servlet-mapping>
+    <servlet-name>DrawingConclusionServlet</servlet-name>
+    <url-pattern>/drawingConclusionAJAX</url-pattern>
+  </servlet-mapping>  
+  
    <!--
    END - just to know where to place the additional servlets
    -->

--- a/productMods/js/drawingConclusion/ajaxController.js
+++ b/productMods/js/drawingConclusion/ajaxController.js
@@ -1,0 +1,36 @@
+
+
+class DTAJAX {
+
+	static callWithout(object){
+		$.ajax({
+			type : 'POST',
+			context : this,
+			dataType : 'json',
+			url : baseUrl + "dataTransformationAJAX",
+			data : "requestData=" + JSON.stringify(
+					$.extend(object, {editKey : editKey, subjectUri : subjectUri}))
+		})
+	}
+	
+	static call(object, returnFunction, flag){
+		
+		PopUpController.init("Please wait")
+		$.ajax({
+			type : 'POST',
+			context : this,
+			dataType : 'json',
+			url : baseUrl + "drawingConclusionAJAX",
+			data : "requestData=" + JSON.stringify(
+					$.extend(object, {editKey : editKey, subjectUri : subjectUri}))
+		}).done((function(msg) {
+			if(returnFunction != undefined){
+				returnFunction(msg)
+			}
+			if(flag === undefined){
+				PopUpController.done()	
+			}
+		}).bind(this))
+	}
+	
+}

--- a/productMods/js/drawingConclusion/main.js
+++ b/productMods/js/drawingConclusion/main.js
@@ -1,0 +1,144 @@
+
+class Main {
+	
+	constructor(){
+	
+		this.initUI()
+		this.loadExistingData()
+	}
+	
+	initUI (){
+		
+		//BUTTONS
+		this.submit = $("#submit")
+		this.cancel = $("#cancel")
+		this.done = $("#done")
+		this.edit = $("#edit")
+		this.del = $("#delete")
+
+		this.validContainer = $("#validContainer")
+		this.errorMsg = $("#errorMessage")
+
+		this.textArea = $("#conclusionValue").bind('input propertychange', (this.change).bind(this))
+		this.submit.click((this.submitRoutine).bind(this))
+		this.edit.click((this.editRoutine).bind(this))
+		this.del.click((this.deleteRoutine).bind(this))
+
+		this.cancel.click(util.redirect)
+		this.done.click(util.redirect)
+		
+		if(objectUri != null){
+			this.submit.hide()
+			this.cancel.hide()
+		} else {
+			this.done.hide()
+			this.edit.hide()
+			this.del.hide()
+		}
+	}
+	
+	loadExistingData(){
+		
+		var existing = null
+		if(objectUri == null){
+			existing = "false"
+		} else {
+			existing = "true"
+		}
+		DTAJAX.call({
+			task : "initial",
+			existing : existing,
+			objectUri : objectUri,
+		}, (this.init).bind(this))
+	}
+	
+	init (msg){
+		
+		this.dataObject = msg.data;
+		this.dataObject.drawingConclusionLabel = this.process(this.dataObject.drawingConclusionType)
+		this.dataObject.inputTypeLabel = this.process(this.dataObject.inputType)
+		this.dataObject.conclusionLabel = this.process(this.dataObject.conclusionType)
+
+		
+		if(this.dataObject.conclusionValue != null){
+			this.textArea.text(this.dataObject.conclusionValue)
+		} else {
+			this.dataObject.conclusionValue = null
+		}
+		
+		if(this.dataObject.inputInstance == ""){
+			this.errorMsg.text("Please add " + this.dataObject.inputTypeLabel + " to the investigation")
+			this.submit.hide()
+			this.validContainer.hide()
+		}
+		this.initValues();
+		
+		if(objectUri != null){
+			this.dataObject.drawingConclusionInstance = objectUri
+			this.dataObject.newConlusionValue = null	
+		}
+	}
+
+
+	initValues(){
+	
+		$("#drawingConclusionLabel").text(this.dataObject.drawingConclusionLabel)
+		$("#inputTypeLabel").text(this.dataObject.inputTypeLabel)
+		$("#inputValue").text(this.dataObject.inputValue)
+	}
+	
+	
+	change(){
+		
+		if(objectUri != null){
+			this.dataObject.newConclusionValue = this.textArea.val()	
+		} else {
+			//Just set the value
+			this.dataObject.conclusionValue = this.textArea.val()
+		}
+	}
+	
+	editRoutine(){
+	
+		if(this.dataObject.newConclusionValue == null){
+			alert("Please change the conclusion text")
+		} else {
+			this.dataObject.task = "edit"
+			DTAJAX.call(this.dataObject, (function(msg){
+				//Do nothing
+			}).bind(this))	
+		}
+	}
+
+	deleteRoutine(){
+		
+		this.dataObject.task = "delete"
+		DTAJAX.call(this.dataObject, (function(msg){
+			//Do nothing
+			util.redirect()
+		}).bind(this))	
+	}
+	
+	submitRoutine(){
+		
+		if(this.dataObject.conclusionValue == null){
+			alert("Please set conclusion text")
+		} else {
+			this.dataObject.task = "save"
+			DTAJAX.call(this.dataObject,(function(msg){
+				util.redirect()
+			}).bind(this))
+		}
+	}
+	
+	process(input){
+		if(input === undefined){
+			return "undefined"
+		} else{
+			var str = input.split("#")[1]
+			if(str == undefined) str = "undefined"
+			str = str.replace(".", " ")
+			return str.replace("_", " ")
+		}
+	}
+}

--- a/productMods/templates/freemarker/customEntryForm/drawingConclusion.ftl
+++ b/productMods/templates/freemarker/customEntryForm/drawingConclusion.ftl
@@ -1,0 +1,64 @@
+<#include "formCSS.ftl">
+<#include "cssImport.ftl">
+<#include "UIscriptImport.ftl">
+
+<#import "lib-import.ftl" as imp> 
+
+<@imp.js url="drawingConclusion/ajaxController" />
+<@imp.js url="drawingConclusion/main" />
+
+
+<div class = "mainFormTitle margin10"  id = "drawingConclusionLabel">
+	Drawing conclusion
+</div>
+
+<div id = "validContainer">
+	<div>
+		<div class = "inlineTitle"> Input </div>
+		<div class = "inlineTitle" id = "inputTypeLabel"> </div>
+		<div class = "inlineTitle" id = "inputValue"> </div>
+	</div>
+	<div class = "title">
+		Conclusion
+	</div>
+	<textarea class="margin10H" id = "conclusionValue" rows="7" cols="80"></textArea>
+</div>
+
+<div class = "margin10" id = "errorMessage">
+</div>
+
+<div class = "margin10V" id = "buttonContainer">
+	<div class = "generalButton hoverClass" id = "submit"> Submit </div>
+	<div class = "generalButton hoverClass" id = "cancel"> Cancel </div>
+	<div class = "generalButton hoverClass" id = "done" >	Done </div>
+	<div class = "generalButton hoverClass" id = "edit" > Edit </div>
+	<div class = "generalButton hoverClass" id = "delete" > Delete </div>
+</div>
+<div id = "popUpContainer">
+</div>
+
+<script>
+ 
+	var imgSrc = "${urls.base}/images/general/"
+	var baseUrl = "${urls.base}/"
+	var editKey = "${editConfiguration.editKey}"
+	var subjectUri = "${editConfiguration.subjectUri}"
+	var dataSaveUri = baseUrl + "dataGenerator"
+	var Global = new Object()
+	Global.buttonID = 0
+	var debug = false
+	<#if editConfiguration.objectUri?has_content>
+    	var	objectUri = '${editConfiguration.objectUri}'
+    <#else>
+   		 var objectUri = null
+    </#if>
+    <#if editConfiguration.rangeUri?has_content>
+    	var	rangeUri = '${editConfiguration.rangeUri}'
+    <#else>
+    	var	rangeUri = null
+    </#if>
+    
+	$(document).ready(function(){
+		new Main()	
+	})
+</script>

--- a/rdf/display/firsttime/drawingConclusionFauxProperty.n3
+++ b/rdf/display/firsttime/drawingConclusionFauxProperty.n3
@@ -1,0 +1,31 @@
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+@prefix owl: <http://www.w3.org/2002/07/owl#> .
+@prefix : <http://vitro.mannlib.cornell.edu/ns/vitro/ApplicationConfiguration#> .
+@prefix display: <http://vitro.mannlib.cornell.edu/ontologies/display/1.1#> .
+@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix datagetter: <java:edu/cornell/mannlib/vitro/webapp/utils/datagetter/> .
+@prefix vitro: <http://vitro.mannlib.cornell.edu/ns/vitro/0.7#> .
+@prefix role:  <http://vitro.mannlib.cornell.edu/ns/vitro/role#> .
+@prefix local: <http://vitro.mannlib.cornell.edu/ns/vitro/siteConfig/> .
+@prefix vivo: <http://vivoweb.org/ontology/core#> . 
+@prefix obo: <http://purl.obolibrary.org/obo/> .
+
+
+local:drawingConclusionContext a :ConfigContext ;
+    :hasConfiguration local:drawingConclusionConfig ;
+    :configContextFor obo:BFO_0000051 ;
+    :qualifiedByDomain <http://purl.obolibrary.org/obo/OBI_0000066> ;
+    :qualifiedBy obo:OBI_0000338 .
+
+local:drawingConclusionConfig a :ObjectPropertyDisplayConfig ;
+    rdfs:label "drawing a conclusion"@en-US ;
+    :displayName "drawing  a conclusion" ;
+    :listViewConfigFile "listViewConfig-fauxPropertyDefault.xml"^^xsd:string ;
+    vitro:displayRankAnnot 90;
+    vitro:hiddenFromDisplayBelowRoleLevelAnnot role:public ;
+    vitro:prohibitedFromUpdateBelowRoleLevelAnnot role:public ;
+    vitro:selectFromExistingAnnot   "true"^^xsd:boolean ;
+    vitro:offerCreateNewOptionAnnot "true"^^xsd:boolean ;
+    vitro:customEntryFormAnnot "edu.cornell.mannlib.vitro.webapp.edit.n3editing.configuration.generators.DrawingConclusionGenerator"^^xsd:string ;
+    :propertyGroup <http://vivoweb.org/ontology#vitroPropertyGroupoverview> .

--- a/src/edu/cornell/mannlib/vitro/webapp/edit/n3editing/configuration/generators/DrawingConclusionGenerator.java
+++ b/src/edu/cornell/mannlib/vitro/webapp/edit/n3editing/configuration/generators/DrawingConclusionGenerator.java
@@ -1,0 +1,61 @@
+/* $This file is distributed under the terms of the license in /doc/license.txt$ */
+
+package edu.cornell.mannlib.vitro.webapp.edit.n3editing.configuration.generators;
+
+import static edu.cornell.mannlib.vitro.webapp.modelaccess.ModelNames.DISPLAY;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import javax.servlet.http.HttpSession;
+
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
+
+import com.hp.hpl.jena.ontology.OntModel;
+import com.hp.hpl.jena.rdf.model.Literal;
+
+import edu.cornell.mannlib.vitro.webapp.application.ApplicationUtils;
+import edu.cornell.mannlib.vitro.webapp.beans.Individual;
+import edu.cornell.mannlib.vitro.webapp.beans.ObjectProperty;
+import edu.cornell.mannlib.vitro.webapp.beans.VClass;
+import edu.cornell.mannlib.vitro.webapp.controller.VitroRequest;
+import edu.cornell.mannlib.vitro.webapp.dao.DisplayVocabulary;
+import edu.cornell.mannlib.vitro.webapp.dao.VitroVocabulary;
+import edu.cornell.mannlib.vitro.webapp.dao.WebappDaoFactory;
+import edu.cornell.mannlib.vitro.webapp.dao.vclassgroup.ProhibitedFromSearch;
+import edu.cornell.mannlib.vitro.webapp.edit.n3editing.VTwo.EditConfigurationUtils;
+import edu.cornell.mannlib.vitro.webapp.edit.n3editing.VTwo.EditConfigurationVTwo;
+import edu.cornell.mannlib.vitro.webapp.edit.n3editing.VTwo.fields.ChildVClassesOptions;
+import edu.cornell.mannlib.vitro.webapp.edit.n3editing.VTwo.fields.FieldVTwo;
+import edu.cornell.mannlib.vitro.webapp.edit.n3editing.VTwo.fields.IndividualsViaObjectPropetyOptions;
+import edu.cornell.mannlib.vitro.webapp.edit.n3editing.configuration.validators.AntiXssValidation;
+import edu.cornell.mannlib.vitro.webapp.i18n.I18n;
+import edu.cornell.mannlib.vitro.webapp.modelaccess.ModelAccess;
+import edu.cornell.mannlib.vitro.webapp.modules.searchEngine.SearchEngine;
+import edu.cornell.mannlib.vitro.webapp.modules.searchEngine.SearchEngineException;
+import edu.cornell.mannlib.vitro.webapp.modules.searchEngine.SearchQuery;
+import edu.cornell.mannlib.vitro.webapp.modules.searchEngine.SearchResponse;
+import edu.cornell.mannlib.vitro.webapp.modules.searchEngine.SearchResultDocumentList;
+import edu.cornell.mannlib.vitro.webapp.search.VitroSearchTermNames;
+import edu.cornell.mannlib.vitro.webapp.utils.FrontEndEditingUtils;
+import edu.cornell.mannlib.vitro.webapp.utils.FrontEndEditingUtils.EditMode;
+
+public class DrawingConclusionGenerator implements EditConfigurationGenerator {
+
+	private Log log = LogFactory.getLog(DrawingConclusionGenerator.class);	
+
+  @Override
+  public EditConfigurationVTwo getEditConfiguration(VitroRequest vreq,
+          HttpSession session) throws Exception {
+
+    EditConfigurationVTwo editConfig = new EditConfigurationVTwo();
+    editConfig.setTemplate("drawingConclusion.ftl");
+    editConfig.setSubjectUri(EditConfigurationUtils.getSubjectUri(vreq));
+    editConfig.setObject(EditConfigurationUtils.getObjectUri(vreq));
+    return editConfig;
+  }
+}    

--- a/src/edu/cornell/mannlib/vitro/webapp/search/controller/DrawingConclusionAJAXController.java
+++ b/src/edu/cornell/mannlib/vitro/webapp/search/controller/DrawingConclusionAJAXController.java
@@ -1,0 +1,346 @@
+package edu.cornell.mannlib.vitro.webapp.search.controller;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import javax.servlet.ServletException;
+import javax.servlet.http.HttpServletResponse;
+
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
+import org.json.JSONArray;
+import org.json.JSONException;
+import org.json.JSONObject;
+
+import rdfbones.formProcessing.WebappConnector;
+import rdfbones.graphData.Graph;
+import rdfbones.lib.ArrayLib;
+import rdfbones.lib.JSON;
+import rdfbones.lib.SPARQLDataGetter;
+import rdfbones.lib.SPARQLUtils;
+import rdfbones.lib.StringSPARQLDataGetter;
+import rdfbones.rdfdataset.*;
+import webappconnector.VIVOWebappConnector;
+import edu.cornell.mannlib.vitro.webapp.beans.DataPropertyStatementImpl;
+import edu.cornell.mannlib.vitro.webapp.beans.ObjectPropertyStatementImpl;
+import edu.cornell.mannlib.vitro.webapp.controller.VitroRequest;
+import edu.cornell.mannlib.vitro.webapp.controller.ajax.VitroAjaxController;
+import edu.cornell.mannlib.vitro.webapp.dao.DataPropertyStatementDao;
+import edu.cornell.mannlib.vitro.webapp.dao.InsertException;
+import edu.cornell.mannlib.vitro.webapp.dao.NewURIMakerVitro;
+import edu.cornell.mannlib.vitro.webapp.dao.ObjectPropertyStatementDao;
+import edu.cornell.mannlib.vitro.webapp.dao.PropertyInstanceDao;
+import edu.cornell.mannlib.vitro.webapp.dao.jena.N3Utils;
+import edu.cornell.mannlib.vitro.webapp.dao.jena.QueryUtils;
+import edu.cornell.mannlib.vitro.webapp.edit.n3editing.VTwo.NewURIMaker;
+
+/**
+ * AutocompleteController generates autocomplete content via the search index.
+ */
+
+public class DrawingConclusionAJAXController extends VitroAjaxController {
+
+  public static final String PARAMETER_UPLOADED_FILE = "datafile";
+
+  private static final long serialVersionUID = 1L;
+  private static final Log log = LogFactory
+      .getLog(DrawingConclusionAJAXController.class);
+
+  NewURIMaker newUri;
+  JSONObject requestData;
+
+  String subjectUri;
+  String objectUri;
+
+  String drawingConclusionInstance;
+  String drawingConclusionType;
+  
+  String inputValue;
+  String inputInstance;
+  String inputType;
+  
+  String conclusionType;
+  String conclusionInstance;
+  String conlusionValue;
+  
+  String editKey;
+  JSONObject resp = new JSONObject();
+
+  private static Map<String, String> prefixDef = new HashMap<String, String>();
+
+  @Override
+  protected void doRequest(VitroRequest vreq, HttpServletResponse response)
+    throws IOException, ServletException {
+
+    WebappConnector connector = new VIVOWebappConnector(vreq);
+    Graph connectorGraph = new Graph();
+    connectorGraph.setWebapp(connector);
+    this.newUri = new NewURIMakerVitro(vreq.getWebappDaoFactory());
+
+    this.requestData = JSON.getObject(vreq.getParameter("requestData"));
+    editKey = getParameter("editKey");
+
+    resp = new JSONObject();
+    JSONObject data = JSON.obj();
+
+    Map<String, String> objectMap = new HashMap<String, String>();
+    Map<String, String> literalMap = new HashMap<String, String>();
+    
+    if(getParameter("task").equals("initial")){
+
+      subjectUri = getParameter("subjectUri");
+      StringSPARQLDataGetter typeDataGetter =
+          new StringSPARQLDataGetter(connectorGraph, SPARQL_types(),
+              ArrayLib.getList("drawingConclusionType", "conclusionType", "inputType"), null, 1);
+            
+      JSONObject types = (JSONObject) typeDataGetter.getSingleResult((ArrayLib.getList(subjectUri)));
+     
+      JSON.copyValue(data, types, "drawingConclusionType");
+      JSON.copyValue(data, types, "conclusionType");
+      JSON.copyValue(data, types, "inputType");
+
+      if(!getParameter("existing").equals("true")){
+
+        StringSPARQLDataGetter inputDataGetter =
+            new StringSPARQLDataGetter(connectorGraph, SPARQL_existingInput(),
+                ArrayLib.getList("inputInstance"), ArrayLib.getList("inputValue"), 1);
+        inputType = JSON.string(types, "inputType");
+        JSONObject inputData = inputDataGetter.getSingleResult(ArrayLib.getList(subjectUri, inputType));
+
+        JSON.copyValue(data, inputData, "inputInstance");
+        JSON.copyValue(data, inputData, "inputValue");
+      }
+      JSON.put(resp, "data", data);
+    }
+    
+    if(getParameter("existing").equals("true")){
+      objectUri = getParameter("objectUri");
+      StringSPARQLDataGetter existingDataGetter =
+          new StringSPARQLDataGetter(connectorGraph, SPARQ_existingData(),
+              ArrayLib.getList("inputInstance", "conclusionInstance"), ArrayLib.getList("inputValue", "conclusionValue"), 1);
+       JSONObject existingData = existingDataGetter.getSingleResult(ArrayLib.getList(objectUri));
+       
+       JSON.copyValue(data, existingData, "inputInstance");
+       JSON.copyValue(data, existingData, "conclusionInstance");
+       JSON.copyValue(data, existingData, "inputValue");
+       JSON.copyValue(data, existingData, "conclusionValue");
+    }
+    
+    switch(getParameter("task")){
+    
+    case "save" :
+      
+      objectMap.put("subjectUri",getParameter("subjectUri"));
+      objectMap.put("drawingConclusionInstance", this.getUnusedURI());
+      objectMap.put("drawingConclusionType", getParameter("drawingConclusionType"));
+      objectMap.put("inputInstance", getParameter("inputInstance"));
+      objectMap.put("conclusionType", getParameter("conclusionType"));
+      objectMap.put("conclusionInstance", this.getUnusedURI());
+
+      literalMap.put("conclusionValue", getParameter("conclusionValue"));
+      literalMap.put("drawingConclusionLabel", getParameter("drawingConclusionLabel"));
+      literalMap.put("conclusionLabel", getParameter("conclusionLabel"));
+
+      String toAdd1 = this.getTripleString(objectMap, literalMap);
+      resp("triplesToAdd", toAdd1);
+      if(connector.addTriples(toAdd1, editKey)){
+        resp("success", "true");
+      } else {
+        resp("success", "false");
+      }
+      break;
+     
+    case "delete":
+      
+      objectMap.put("subjectUri",getParameter("subjectUri"));
+      objectMap.put("drawingConclusionInstance", getParameter("drawingConclusionInstance"));
+      objectMap.put("drawingConclusionType", getParameter("drawingConclusionType"));
+      objectMap.put("inputInstance", getParameter("inputInstance"));
+      objectMap.put("conclusionType", getParameter("conclusionType"));
+      objectMap.put("conclusionInstance", getParameter("conclusionInstance"));
+
+      literalMap.put("conclusionValue", getParameter("conclusionValue"));
+      literalMap.put("drawingConclusionLabel", getParameter("drawingConclusionLabel"));
+      literalMap.put("conclusionLabel", getParameter("conclusionLabel"));
+      
+      String toRemove2 = this.getTripleString(objectMap, literalMap);
+      resp("triplesToAdd", toRemove2);
+      if(connector.removeTriples(toRemove2, editKey)){
+        resp("success", "true");
+      } else {
+        resp("success", "false");
+      }
+      break;
+     
+      
+    case "edit":
+      
+      String toRemove =
+          "<" + getParameter("conclusionInstance") + "> " + "<http://w3id.org/rdfbones/extensions/FrSexEst#HasText> " 
+                + " '" + getParameter("conclusionValue") + "'";
+      
+      String toAdd2 =
+          "<" + getParameter("conclusionInstance") + "> " + "<http://w3id.org/rdfbones/extensions/FrSexEst#HasText> " 
+              + " '" + getParameter("newConclusionValue") + "'";
+      
+      resp("toRemove", toRemove);
+      resp("toAdd", toAdd2);
+      connector.removeTriples(toRemove, editKey);
+      connector.addTriples(toAdd2, editKey);
+      break;
+
+    default:
+      break;
+    }
+
+    JSON.put(resp, "queries", connector.getQueries());
+    response.getWriter().write(resp.toString());
+  }
+
+  public String getUnusedURI() {
+    try {
+      return this.newUri.getUnusedNewURI(null);
+    } catch (InsertException e) {
+      e.printStackTrace();
+    }
+    return new String("");
+  }
+
+  private static String getDataTriples() {
+
+    String triples =  ""
+            + " ?subjectUri                       obo:BFO_0000051     ?drawingConclusionInstance . \n"
+            + " ?drawingConclusionInstance        rdf:type            ?drawingConclusionType . \n "
+            + " ?drawingConclusionInstance        rdfs:label          ?drawingConclusionLabel . \n "
+            + " ?drawingConclusionInstance        obo:OBI_0000293     ?inputInstance . \n"
+            + " ?drawingConclusionInstance        obo:OBI_0000299     ?conclusionInstance . \n"
+            + " ?conclusionInstance               rdf:type            ?conclusionType . \n "
+            + " ?conclusionInstance               rdfs:label          ?conclusionLabel . \n "
+            + " ?conclusionInstance   <http://w3id.org/rdfbones/extensions/FrSexEst#HasText> ?conclusionValue . \n";
+    return triples;
+  }
+
+  public String SPARQL_types() {
+
+    // In this case the subjectUri
+    String query = ""
+       +  "  SELECT ?drawingConclusionType ?conclusionType ?inputType  \n"
+       +  "     WHERE { \n"
+       +  "       ?subjectUri       vitro:mostSpecificType       ?investigationType .  \n"
+       +  "       ?investigationType      rdfs:subClassOf   ?restrictionDC .  \n"
+       +  "       ?restrictionDC        owl:onProperty      obo:BFO_0000051 . \n"
+       +  "       ?restrictionDC        owl:someValuesFrom  ?drawingConclusionType .  \n"
+       +  "       ?drawingConclusionType    rdfs:subClassOf   obo:OBI_0000338 . \n"
+       +  "       ?drawingConclusionType      rdfs:subClassOf                 ?restrictionInput . \n"
+       +  "       ?restrictionInput           owl:onProperty                  obo:OBI_0000293 . \n"
+       +  "       ?restrictionInput           owl:onClass                             ?inputType . \n"
+       +  "       ?drawingConclusionType      rdfs:subClassOf                 ?restrictionOutput . \n"
+       +  "       ?restrictionOutput                  owl:onProperty                  obo:OBI_0000299 . \n"
+       +  "       ?restrictionOutput                owl:someValuesFrom                    ?conclusionType . \n"
+       +  "       FILTER ( ?subjectUri = <input1> ) \n"
+       +  "     } \n" ;
+    return query;
+  }
+
+  public String SPARQL_existingInput() {
+
+    String query = "" +
+            "  SELECT ?inputInstance ?inputValue \n" + 
+            "  WHERE {\n" + 
+            "   ?subjectUri     obo:BFO_0000051   ?studyDesignExecution .\n" + 
+            "   ?studyDesignExecution obo:BFO_0000051   ?dataTransformation .\n" + 
+            "   ?dataTransformation   obo:OBI_0000299   ?inputInstance .\n" + 
+            "   ?inputInstance      obo:IAO_0000004   ?inputValue .\n" + 
+            "   ?inputInstance      rdf:type        ?inputType .\n" + 
+            "   FILTER ( ?subjectUri = <input1> ) .\n" + 
+            "   FILTER ( ?inputType = <input2> ) .\n" + 
+            "}";
+    
+    return query;
+  }
+
+  public String SPARQ_existingData(){
+    
+    String query = "SELECT ?inputInstance ?inputValue ?conclusionInstance ?conclusionValue\n" + 
+        "  WHERE {    \n"  + 
+        "  ?objectUri            obo:OBI_0000293   ?inputInstance . \n" + 
+        "  ?inputInstance        obo:IAO_0000004   ?inputValue .  \n" + 
+        "  ?objectUri            obo:OBI_0000299   ?conclusionInstance . \n" + 
+        "  ?conclusionInstance      <http://w3id.org/rdfbones/extensions/FrSexEst#HasText>   ?conclusionValue .  \n" + 
+        "  FILTER ( ?objectUri = <input1> ) .   \n   " + 
+        "}";
+    return query;
+  }
+  
+  public String SPARQL_inputs() {
+
+    String query =
+        ""
+            + "SELECT ?measurementDatum ?measurementDatumLabel ?cardinality ?catLabel ?measurementValue (datatype(?measurementValue) as ?measurementValueType) "
+            + "WHERE { "
+            + "  ?subjectUri                 obo:BFO_0000051               ?assayOrDT . "
+            + "  ?assayOrDT                  obo:OBI_0000299               ?measurementDatum . "
+            + "  ?measurementDatum           rdfs:label                    ?measurementDatumLabel . "
+            + "  ?measurementDatum           rdf:type                      ?measurementDatumType ."
+            + "  ?dataTransformationType     rdfs:subClassOf               ?restriction . "
+            + "  ?restriction                owl:onProperty                obo:OBI_0000293 . "
+            + "  ?restriction                owl:onClass                   ?measurementDatumType . "
+            + "  OPTIONAL { ?measurementDatum       obo:IAO_0000004               ?measurementValue . } "
+            + "  OPTIONAL {  "
+            + "     ?measurementDatum               obo:OBI_0000999          ?categoricalLabel . "
+            + "     ?categoricalLabel               rdfs:label               ?catLabel . "
+            + "  }" + "  FILTER ( ?subjectUri = <input1> ) "
+            + "  FILTER ( ?dataTransformationType = <input2> ) " + "}";
+    return query;
+  }
+
+  public String SPARQL_exsistingInput() {
+
+    String query =
+        "" + "SELECT ?input " + "WHERE { "
+            + "  ?dataTransformation     obo:OBI_0000293          ?input . "
+            + "  FILTER ( ?dataTransformation = <input1> ) " + "}";
+    return query;
+  }
+
+  // In this case the subjectUri
+  public String SPARQL_OutputTypes() {
+
+    String query =
+        ""
+            + "SELECT ?drawingConclusionType ?conclusionType ?inputType"
+            + "  ?measurementDatumType ?label "
+            + "WHERE { "
+            + "     ?subjectUri          vitro"
+            + "     ?DTType              rdfs:subClassOf              ?restriction1 . \n"
+            + "     ?restriction1        owl:onProperty               obo:OBI_0000299 . \n "
+            + "     ?restriction1        owl:qualifiedCardinality     ?cardinality . \n "
+            + "     ?restriction1        owl:onClass                  ?measurementDatumType . \n "
+            + "     OPTIONAL { ?measurementDatumType      rdfs:label         ?label . }  \n"
+            + "     FILTER ( ?subjectUri = <input1> )" 
+            + "}";
+    return query;
+  }
+ 
+  String getParameter(String key) {
+
+    return JSON.string(requestData, key);
+  }
+
+  void resp(String key, String value) {
+
+    JSON.put(resp, key, value);
+  }
+
+  private String getTripleString(Map<String, String> objectMap, Map<String, String>  literalMap) {
+
+    String triplesString = getDataTriples();
+    triplesString = QueryUtils.subUrisForQueryLiterals(triplesString, literalMap);
+    triplesString = QueryUtils.subUrisForQueryVars(triplesString, objectMap);
+    return triplesString;
+  }
+
+}

--- a/src/rdfbones/lib/StringSPARQLDataGetter.java
+++ b/src/rdfbones/lib/StringSPARQLDataGetter.java
@@ -5,6 +5,7 @@ import java.util.List;
 import java.util.Map;
 
 import org.json.JSONArray;
+import org.json.JSONObject;
 
 import edu.cornell.mannlib.vitro.webapp.dao.jena.N3Utils;
 import edu.cornell.mannlib.vitro.webapp.dao.jena.QueryUtils;
@@ -48,11 +49,15 @@ public class StringSPARQLDataGetter extends SPARQLDataGetter{
 			this.queryString = this.queryString.replace("input" + Integer.toString(n), str);
 			n++;
 		}
-		log.info(queryString);
 		return QueryUtils.getJSON(this.mainGraph.getWebapp().sparqlResult(queryString, this.urisToSelect,
 				this.literalsToSelect));
 	}
 
+  public JSONObject getSingleResult(List<String> inputValues) {
+
+    return  JSON.object(this.getJSON(inputValues), 0);
+  }
+	
 	public List<Map<String, String>> getData(List<String> inputValues) {
 
 		this.inputValues = inputValues;


### PR DESCRIPTION
I experienced that the faux properties working only reliably if the database is completely cleared and VIVO loads them from the rdf/display/firsttime directory, or added through the ontology editor. But if the config n3 is loaded through the Add/Remove RDF Data menu, then they appear on the profile pages only occasionally. 
The branch contains the file rdf/display/firsttime/drawingConclusionFauxProperty.n3. But if you do not want to wipe the production machine then do the following:


Step I : Find the property 'has part' in the object properties of the OBO Foundry ontology 
![screen shot 2017-03-27 at 01 18 01](https://cloud.githubusercontent.com/assets/7580884/24336229/5f1e0c0e-128b-11e7-98c1-dacb64bb0b91.png)

Step II: Go to the faux properties and click on create new:
![screen shot 2017-03-27 at 01 18 13](https://cloud.githubusercontent.com/assets/7580884/24336230/6125a58e-128b-11e7-9195-e05928f9edd5.png)

Step III : Set label, property group, domain and range:
![screen shot 2017-03-27 at 01 18 30](https://cloud.githubusercontent.com/assets/7580884/24336231/64242198-128b-11e7-946e-b1c2c07b4c96.png)

Step IV : Set custom entry form:
![screen shot 2017-03-27 at 01 18 37](https://cloud.githubusercontent.com/assets/7580884/24336232/66de81da-128b-11e7-805c-782ecfd5bd5a.png)



